### PR TITLE
Ignore A005 because it complains about select.py

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -8,6 +8,7 @@ select = [
 ]
 
 ignore = [
+    "A005",   # select.py shadows a standard library
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
     "ARG001",
     "ARG002",


### PR DESCRIPTION
Until we get a better fix from upstream.